### PR TITLE
constructor method for WP_Widget is deprecated

### DIFF
--- a/acf-widget.php
+++ b/acf-widget.php
@@ -26,7 +26,7 @@ class ACF_Widget extends WP_Widget
 			"description"   => "Easily create custom widgets using ACF"
 			);
 
-		parent::WP_Widget("ACF_Widget", "ACF Widget", $widget_options);
+		parent::__construct("ACF_Widget", "ACF Widget", $widget_options);
 	}
 
 	function form($instance)


### PR DESCRIPTION
Constructor method for WP_Widget is deprecated since 4.3.0.
So I changed parent::WP_Widget into parent::__construct.